### PR TITLE
Add optional-chaining operator to prices

### DIFF
--- a/src/components/EventsDashboard/EventCard.tsx
+++ b/src/components/EventsDashboard/EventCard.tsx
@@ -92,8 +92,8 @@ export const EventCard: React.FC<EventCardProps> = ({ event, user, registered, s
     `${months[dateString.getMonth()]} ${dateString.getDate()}, ${event.year}` + " " + `${dateString.toTimeString().slice(0, 5)}`;
 
   const eventPricingText =
-    `${event.pricing && event.pricing > 0 ? "$" + event.pricing.members.toFixed(2) : "Free!"} ` +
-    `${event.pricing.nonMembers ? `(Non-members ${event.pricing?.nonMembers.toFixed(2)})` : "(Members only)"}`;
+    `${event.pricing && event.pricing > 0 ? "$" + event.pricing?.members.toFixed(2) : "Free!"} ` +
+    `${event.pricing?.nonMembers ? `(Non-members ${event.pricing?.nonMembers.toFixed(2)})` : "(Members only)"}`;
 
   return (
     <>

--- a/src/pages/admin/event/[eventId]/[year]/stats/index.tsx
+++ b/src/pages/admin/event/[eventId]/[year]/stats/index.tsx
@@ -2,11 +2,11 @@ import { AttendeeBasicInformation } from "@/types";
 import { GetServerSideProps } from "next";
 import { useRouter } from "next/router";
 import { fetchRegistrationData } from "@/lib/dbUtils";
-import PercentageBars from "@/components/Stats/PercentageBars";
-import ChartBox from "@/components/Stats/ChartBox";
-import StatsTable from "@/components/Stats/StatsTable";
-import BarChart from "@/components/Stats/BarChart";
-import PieChart from "@/components/Stats/PieChart";
+import PercentageBars from "@/components/stats/PercentageBars";
+import ChartBox from "@/components/stats/ChartBox";
+import StatsTable from "@/components/stats/StatsTable";
+import BarChart from "@/components/stats/BarChart";
+import PieChart from "@/components/stats/PieChart";
 
 type Props = {
   initialData: AttendeeBasicInformation[] | null;

--- a/src/pages/admin/event/[eventId]/[year]/stats/index.tsx
+++ b/src/pages/admin/event/[eventId]/[year]/stats/index.tsx
@@ -2,11 +2,11 @@ import { AttendeeBasicInformation } from "@/types";
 import { GetServerSideProps } from "next";
 import { useRouter } from "next/router";
 import { fetchRegistrationData } from "@/lib/dbUtils";
-import PercentageBars from "@/components/stats/PercentageBars";
-import ChartBox from "@/components/stats/ChartBox";
-import StatsTable from "@/components/stats/StatsTable";
-import BarChart from "@/components/stats/BarChart";
-import PieChart from "@/components/stats/PieChart";
+import ChartBox from "@/components/Stats/ChartBox";
+import StatsTable from "@/components/Stats/StatsTable";
+import BarChart from "@/components/Stats/BarChart";
+import PieChart from "@/components/Stats/PieChart";
+import PercentageBars from "@/components/Stats/PercentageBars";
 
 type Props = {
   initialData: AttendeeBasicInformation[] | null;

--- a/src/pages/event/[eventId]/[year]/index.tsx
+++ b/src/pages/event/[eventId]/[year]/index.tsx
@@ -248,7 +248,7 @@ export default function AttendeeFormRegister() {
                     paymentPrice:
                         (user?.isMember
                             ? event.pricing?.members
-                            : event.pricing.nonMembers) * 100,
+                            : event.pricing?.nonMembers) * 100,
                     paymentType: "Event",
                     success_url: `${process.env.REACT_APP_STAGE === "local"
                         ? "http://localhost:3000/"
@@ -323,7 +323,7 @@ export default function AttendeeFormRegister() {
                             <p>
                                 This event is available to non-members, but please note that you
                                 will be paying ${event?.pricing?.nonMembers && event?.pricing?.members
-                                    ? (event.pricing.nonMembers - event.pricing.members).toFixed(2)
+                                    ? (event.pricing?.nonMembers - event.pricing?.members).toFixed(2)
                                     : '7.00'} more.
                             </p>
                             <p>


### PR DESCRIPTION
### Notes
Vercel build fails without optional chaining on prices (`?.prices`). This PR adds the `?.`

### Testing
`npm run build` passes, Vercel build dry-run passes