### PR TITLE
Change .env flag for prod and change to V2 URL

### DIFF
--- a/src/lib/dbconfig.ts
+++ b/src/lib/dbconfig.ts
@@ -4,15 +4,15 @@
 //     : aws_exports
 
 export const API_URL =
-process.env.NEXT_PUBLIC_REACT_APP_STAGE === "production"
+process.env.REACT_APP_STAGE === "production"
   ? "https://api.ubcbiztech.com"
-  : process.env.NEXT_PUBLIC_REACT_APP_STAGE === "local"
+  : process.env.REACT_APP_STAGE === "local"
     ? "http://localhost:4000"
     : "https://api-dev.ubcbiztech.com";
 
 export const CLIENT_URL =
-  process.env.NEXT_PUBLIC_REACT_APP_STAGE === "production"
-    ? "https://app.ubcbiztech.com/"
-    : process.env.NEXT_PUBLIC_REACT_APP_STAGE === "local"
+  process.env.REACT_APP_STAGE === "production"
+    ? "https://v2.ubcbiztech.com/"
+    : process.env.REACT_APP_STAGE === "local"
       ? "http://localhost:3000/"
-      : "https://dev.app.ubcbiztech.com/";
+      : "https://dev.v2.ubcbiztech.com/";


### PR DESCRIPTION
### Notes
- Change environment flag from `NEXT_PUBLIC_REACT_APP_STAGE` to `REACT_APP_STAGE` to make prod flag consistent for Vercel prod setup
- Change client side URL to new V2 URLs for URL redirects

### Testing
`npm run build` passes