### PR TITLE
Blueprint NFC Scanning User Flow

### DIFF
--- a/src/components/companion/PageError.tsx
+++ b/src/components/companion/PageError.tsx
@@ -1,0 +1,24 @@
+
+const PageError = ({
+    icon,
+    title,
+    subtitle,
+    message="An unexpected error occurred.",
+}: {
+    icon: React.ReactNode;
+    title: string;
+    subtitle: string;
+    message: string;
+}) => (
+    <div className="w-screen h-screen flex flex-col items-center justify-center bg-gray-50 text-gray-800">
+        <div className="text-red-500 mb-6">{icon}</div>
+        <div className="text-center space-y-4">
+            <h1 className="text-4xl font-bold">{title}</h1>
+            <div className="w-16 h-0.5 bg-gray-300 mx-auto"></div>
+            <h2 className="text-2xl font-semibold">{subtitle}</h2>
+        </div>
+        <p className="mt-8 text-gray-600">{message}</p>
+    </div>
+);
+
+export default PageError;

--- a/src/pages/companion/index.tsx
+++ b/src/pages/companion/index.tsx
@@ -117,7 +117,7 @@ const Companion = () => {
       setEmail(savedEmail);
     }
     setIsLoading(false);
-  });
+  }, []);
 
   useEffect(() => {
     setError("");

--- a/src/pages/companion/index.tsx
+++ b/src/pages/companion/index.tsx
@@ -58,6 +58,7 @@ const Companion = () => {
       setError("");
       setUserRegistration(reg);
       localStorage.setItem("companionEmail", reg.id);
+      localStorage.setItem("externalUserId", reg.externalUserId);
     } else {
       setError("This email does not match an existing entry in our records.");
       setIsLoading(false);
@@ -71,6 +72,7 @@ const Companion = () => {
         method: "GET",
         authenticatedCall: false
       });
+      console.log("Registrations: ", response);
       setRegistrations(response.data);
     } catch (err) {
       setPageError(err as string);

--- a/src/pages/companion/index.tsx
+++ b/src/pages/companion/index.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { fetchBackend } from '@/lib/db';
 import CompanionLayout from '@/components/companion/CompanionLayout';
 import Events from '@/constants/companion-events';
+import { useRouter } from "next/router";
 
 interface Registration {
   id: string;
@@ -32,6 +33,7 @@ const styles = {
 };
 
 const Companion = () => {
+  const router = useRouter();
   const [email, setEmail] = useState("");
   const [pageError, setPageError] = useState("");
   const [error, setError] = useState("");
@@ -40,7 +42,7 @@ const Companion = () => {
   const [userRegistration, setUserRegistration] = useState<Registration | null>(null);
   const [scheduleData, setScheduleData] = useState<Array<{ date: string; title: string }>>([]);
   const [isLoading, setIsLoading] = useState(true);
-
+  const [decodedRedirect, setDecodedRedirect] = useState("");
   const events = Events.sort((a, b) => {
     return a.activeUntil.getTime() - b.activeUntil.getTime();
   });
@@ -58,7 +60,10 @@ const Companion = () => {
       setError("");
       setUserRegistration(reg);
       localStorage.setItem("companionEmail", reg.id);
-      localStorage.setItem("externalUserId", reg.externalUserId);
+
+      if (decodedRedirect != "") {
+        router.push(decodedRedirect);
+      }
     } else {
       setError("This email does not match an existing entry in our records.");
       setIsLoading(false);
@@ -72,7 +77,6 @@ const Companion = () => {
         method: "GET",
         authenticatedCall: false
       });
-      console.log("Registrations: ", response);
       setRegistrations(response.data);
     } catch (err) {
       setPageError(err as string);
@@ -88,10 +92,19 @@ const Companion = () => {
       });
       setEvent(response);
     } catch (err) {
-      console.log("Error while fetching event info: ", err);
       setPageError(err as string);
     }
   };
+
+  useEffect(() => {
+    const search = window.location.search;
+    
+    if (search.startsWith('?=')) {
+      setDecodedRedirect(decodeURIComponent(search.slice(2)));
+    } else {
+      console.log("Malformed redirect URL");
+    }
+  }, [router]);
 
   useEffect(() => {
     setIsLoading(true);

--- a/src/pages/companion/index.tsx
+++ b/src/pages/companion/index.tsx
@@ -57,16 +57,16 @@ const Companion = () => {
   const fetchUserData = async () => {
     const reg = registrations.find((entry) => entry.id.toLowerCase() === email.toLowerCase());
     if (reg) {
-      setError("");
-      setUserRegistration(reg);
-      localStorage.setItem("companionEmail", reg.id);
+        setError("");
+        setUserRegistration(reg);
+        localStorage.setItem("companionEmail", reg.id);
 
-      if (decodedRedirect != "") {
-        router.push(decodedRedirect);
-      }
+        if (decodedRedirect !== "") {
+            router.push(decodedRedirect);
+        }
     } else {
-      setError("This email does not match an existing entry in our records.");
-      setIsLoading(false);
+        setError("This email does not match an existing entry in our records.");
+        setIsLoading(false);
     }
   };
 
@@ -97,14 +97,15 @@ const Companion = () => {
   };
 
   useEffect(() => {
-    const search = window.location.search;
-    
-    if (search.startsWith('?=')) {
-      setDecodedRedirect(decodeURIComponent(search.slice(2)));
-    } else {
-      console.log("Malformed redirect URL");
-    }
-  }, [router]);
+    if (typeof window !== 'undefined') {
+      const search = window.location.search;
+      
+      if (search.startsWith('?=')) {
+        setDecodedRedirect(decodeURIComponent(search.slice(2)));
+      } else {
+        console.log("Malformed redirect URL");
+      }
+  }}, [router]);
 
   useEffect(() => {
     setIsLoading(true);
@@ -116,7 +117,7 @@ const Companion = () => {
       setEmail(savedEmail);
     }
     setIsLoading(false);
-  }, []);
+  });
 
   useEffect(() => {
     setError("");

--- a/src/pages/companion/login/redirect/index.tsx
+++ b/src/pages/companion/login/redirect/index.tsx
@@ -1,0 +1,3 @@
+import Companion from '../..';
+
+export default Companion;

--- a/src/pages/companion/profile/[externalUserId]/index.tsx
+++ b/src/pages/companion/profile/[externalUserId]/index.tsx
@@ -18,7 +18,7 @@ interface Qr {
     type: string;
 }
 
-const index = () => {
+const Index = () => {
     const eventID = "blueprint";
     const year = "2025";
 
@@ -107,7 +107,7 @@ const index = () => {
             setPageError("");
             setUserId(savedId);
         }
-    }, [registrations, localUser, userId]);
+    }, [registrations, localUser, userId, loading, loadingQr, qrData]);
 
     if (loading) {
         return (
@@ -143,4 +143,4 @@ const index = () => {
     }
 };
 
-export default index;
+export default Index;

--- a/src/pages/companion/profile/[externalUserId]/index.tsx
+++ b/src/pages/companion/profile/[externalUserId]/index.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { fetchBackend } from "@/lib/db";
+import Blueprint2025 from "@/components/companion/events/Blueprint2025";
+
+interface Registration {
+    id: string;
+    fname: string;
+    points?: number;
+    [key: string]: any;
+}
+
+const index = () => {
+    const eventID = "blueprint";
+    const year = "2025";
+
+    const router = useRouter();
+    const { externalUserId } = router.query;
+
+    const [userId, setUserId] = useState("");
+    const [registrations, setRegistrations] = useState<Registration[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [pageError, setPageError] = useState("");
+    const [error, setError] = useState("");
+
+    // fetching user data
+    const fetchRegistrations = async () => {
+        try {
+            const response = await fetchBackend({
+                endpoint: `/registrations?eventID=${eventID}&year=${year}`,
+                method: "GET",
+                authenticatedCall: false,
+            });
+            console.log("Registrations: ", response);
+            setRegistrations(response.data);
+        } catch (err) {
+            setPageError(err as string);
+        }
+    };
+
+    useEffect(() => {
+        fetchRegistrations();
+    }, []);
+
+    useEffect(() => {
+        const savedId = localStorage.getItem("externalUserId") || "";
+        const reg = registrations.find(
+            (entry) =>
+                entry.externalUserId.toLowerCase() === savedId.toLowerCase()
+        );
+        if (registrations.length != 0) {
+            setLoading(false);
+        }
+        if (!reg) {
+            setError(
+                "Your UUID does not match an existing entry in our records. Log in to track your connections."
+            );
+            console.log(
+                "Your UUID does not match an existing entry in our records. Log in to track your connections."
+            );
+        } else {
+            setUserId(savedId);
+            console.log("User email: ", userId);
+        }
+    }, [registrations]);
+
+    if (loading) {
+        return <div>Loading...</div>;
+    }
+
+    if (userId == externalUserId) {
+        return <div>your profile</div>; // redirect to your profile
+    } else {
+        return <div>their profile</div>; // redir to their profile
+    }
+};
+
+export default index;

--- a/src/pages/companion/profile/[externalUserId]/index.tsx
+++ b/src/pages/companion/profile/[externalUserId]/index.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import { fetchBackend } from "@/lib/db";
 import PageError from "@/components/companion/PageError";
 import { Loader2, XCircleIcon } from "lucide-react";
-import { set } from "lodash";
+import Events from "@/constants/companion-events";
 
 interface Registration {
     id: string;
@@ -19,9 +19,6 @@ interface Qr {
 }
 
 const Index = () => {
-    const eventID = "blueprint";
-    const year = "2025";
-
     const router = useRouter();
     const [qrData, setQrData] = useState<Qr | null>(null);
     const [qrPath, setQrPath] = useState<string>();
@@ -31,6 +28,18 @@ const Index = () => {
     const [loading, setLoading] = useState(true);
     const [loadingQr, setQrLoading] = useState(true);
     const [pageError, setPageError] = useState("");
+
+    const events = Events.sort((a, b) => {
+        return a.activeUntil.getTime() - b.activeUntil.getTime();
+    });
+
+    const currentEvent =
+        events.find((event) => {
+            const today = new Date();
+            return event.activeUntil > today;
+        }) || events[0];
+
+    const { eventID, year } = currentEvent || {};
 
     // fetching user data from qr code
     const fetchUserID = async (qrId: string) => {
@@ -107,7 +116,7 @@ const Index = () => {
             setPageError("");
             setUserId(savedId);
         }
-    }, [registrations, localUser, userId, loading, loadingQr, qrData]);
+    }, [registrations, localUser, userId]);
 
     if (loading) {
         return (

--- a/src/pages/companion/scan/[qrId]/index.tsx
+++ b/src/pages/companion/scan/[qrId]/index.tsx
@@ -11,7 +11,7 @@ interface Qr {
     type: string;
 }
 
-const index = () => {
+const Index = () => {
     const router = useRouter();
     const { qrId } = router.query;
 
@@ -20,6 +20,7 @@ const index = () => {
 
     const [pageError, setPageError] = useState("");
     const [qrData, setQrData] = useState<Qr | null>(null);
+    const [loadingQr, setQrLoading] = useState(true);
     const [userLoggedIn, setUserLoggedIn] = useState(false);
 
     // fetching QR data
@@ -33,6 +34,7 @@ const index = () => {
 
             const data = await response;
             setQrData(data);
+            setQrLoading(false);
         } catch (err) {
             setPageError(err as string);
         }
@@ -50,7 +52,7 @@ const index = () => {
     };
 
     useEffect(() => {
-        if (qrId) {
+        if (typeof qrId === 'string' && qrId.trim() !== '') {
             fetchQR();
             fetchUser();
         }
@@ -67,7 +69,7 @@ const index = () => {
     useEffect(() => {
         if (qrData) {
             const { type, id } = qrData;
-
+    
             switch (type) {
                 case "NFC_ATTENDEE":
                     handleRedirect(`/companion/profile/${id}`);
@@ -85,8 +87,11 @@ const index = () => {
     }, [qrData, userLoggedIn, router]);
 
     if (
-        !qrData ||
-        !["NFC_ATTENDEE", "NFC_BOOTH", "NFC_WORKSHOP"].includes(qrData.type)
+        !loadingQr &&
+        (!qrData ||
+            !["NFC_ATTENDEE", "NFC_BOOTH", "NFC_WORKSHOP"].includes(
+                qrData.type
+            ))
     ) {
         return (
             <PageError
@@ -106,6 +111,7 @@ const index = () => {
         );
     }
 
+    // loading spinner
     return (
         <div className="w-screen h-screen flex items-center justify-center">
             <Loader2 className="animate-spin" size={50} />
@@ -113,4 +119,4 @@ const index = () => {
     );
 };
 
-export default index;
+export default Index;

--- a/src/pages/companion/scan/[qrId]/index.tsx
+++ b/src/pages/companion/scan/[qrId]/index.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { fetchBackend } from "@/lib/db";
+import { fetchAuthSession } from "@aws-amplify/auth";
+import { Loader2, QrCodeIcon } from "lucide-react";
+import PageError from "@/components/companion/PageError";
+
+interface Qr {
+    data: Record<string, any>;
+    id: string;
+    type: string;
+}
+
+const index = () => {
+    const router = useRouter();
+    const { qrId } = router.query;
+
+    const eventID = "blueprint";
+    const year = "2025";
+
+    const [pageError, setPageError] = useState("");
+    const [qrData, setQrData] = useState<Qr | null>(null);
+    const [userLoggedIn, setUserLoggedIn] = useState(false);
+
+    // fetching QR data
+    const fetchQR = async () => {
+        try {
+            const response = await fetchBackend({
+                endpoint: `/qr/${qrId}/${eventID}/${year}`,
+                method: "GET",
+                authenticatedCall: false,
+            });
+
+            const data = await response;
+            setQrData(data);
+        } catch (err) {
+            setPageError(err as string);
+        }
+    };
+
+    const fetchUser = async () => {
+        try {
+            const { tokens } = await fetchAuthSession();
+            if (tokens) {
+                setUserLoggedIn(true);
+            }
+        } catch (err: any) {
+            setUserLoggedIn(false);
+        }
+    };
+
+    useEffect(() => {
+        if (qrId) {
+            fetchQR();
+            fetchUser();
+        }
+    }, [qrId]);
+
+    const handleRedirect = (path: string) => {
+        if (userLoggedIn) {
+            router.push(path);
+        } else {
+            router.push(`/companion/login/redirect?=${path}`);
+        }
+    };
+
+    useEffect(() => {
+        if (qrData) {
+            const { type, id } = qrData;
+
+            switch (type) {
+                case "NFC_ATTENDEE":
+                    handleRedirect(`/companion/profile/${id}`);
+                    break;
+                case "NFC_BOOTH":
+                    handleRedirect(`/companion/booth/${id}`);
+                    break;
+                case "NFC_WORKSHOP":
+                    handleRedirect(`/companion/workshop/${id}`);
+                    break;
+                default:
+                    console.error("Unsupported QR Data type:", type);
+            }
+        }
+    }, [qrData, userLoggedIn, router]);
+
+    if (
+        !qrData ||
+        !["NFC_ATTENDEE", "NFC_BOOTH", "NFC_WORKSHOP"].includes(qrData.type)
+    ) {
+        return (
+            <PageError
+                icon={<QrCodeIcon size={64} color="#F87171" />}
+                title="Error"
+                subtitle="No such NFC code found"
+                message="Try scanning your NFC card again."
+            />
+        );
+    }
+
+    if (pageError) {
+        return (
+            <div className="w-screen h-screen flex items-center justify-center">
+                {pageError}
+            </div>
+        );
+    }
+
+    return (
+        <div className="w-screen h-screen flex items-center justify-center">
+            <Loader2 className="animate-spin" size={50} />
+        </div>
+    );
+};
+
+export default index;


### PR DESCRIPTION
## Changes:
- Implemented the NFC scanning user flow, redirecting from /companion/scan to /companion/profile
- Added redirect functionality to companion login via URL parameters

## Notes:
- Profiles page will verify if the currently logged-in user is viewing a profile associated with their account.
- Redirects to user dashboard or other attendee's profile still WIP
- Scanning does not yet add the qr data to scannedQRs in db

## Demo:
#### When a user is already logged in
https://github.com/user-attachments/assets/87e64a67-0e50-432b-b607-0e630708c9e4

#### When a user has not logged in
https://github.com/user-attachments/assets/897e1f82-30b9-4b98-80f0-882384014d6b

