### PR TITLE
add case for photobooth

### DIFF
--- a/src/pages/companion/scan/[qrId]/index.tsx
+++ b/src/pages/companion/scan/[qrId]/index.tsx
@@ -68,6 +68,10 @@ const Index = () => {
         Object.assign(body, { eventType: BOOTH_EVENT });
         redirect = `/companion/profile/company/${eventParam}`;
         break;
+      case "NFC_BOOTH":
+        Object.assign(body, { eventType: BOOTH_EVENT });
+        redirect = `/companion/`;
+        break;
       case "NFC_WORKSHOP":
         Object.assign(body, { eventType: WORKSHOP_EVENT });
         redirect = `/companion/`;


### PR DESCRIPTION
## Changes
- added case for NFC_BOOTH, looks janky for now but allows us to keep things separate from booth logic without having it break

<img width="825" alt="image" src="https://github.com/user-attachments/assets/c93aaa3f-de97-4fc0-b5a1-171455849682" />