### PR TITLE
Removed membership price parameter

### DIFF
--- a/src/pages/membership.tsx
+++ b/src/pages/membership.tsx
@@ -113,7 +113,6 @@ const Membership = () => {
         const paymentBody = {
           paymentName: "BizTech Membership",
           paymentImages: ["https://imgur.com/TRiZYtG.png"],
-          paymentPrice: 1000,
           paymentType: "OAuthMember",
           success_url: `${
             process.env.NEXT_PUBLIC_REACT_APP_STAGE === "local"


### PR DESCRIPTION
**Title:**
Remove `paymentPrice` param from payment request body

**Body:**
Removed the `paymentPrice` field from the `/payments` request body.
Payment amount is now set server-side based on `paymentType`.

**Related backend PR:**
https://github.com/ubc-biztech/serverless-biztechapp/pull/526