### PR TITLE
fix middleware auth + event page reroute

### DIFF
--- a/src/components/EventsDashboard/EventCard.tsx
+++ b/src/components/EventsDashboard/EventCard.tsx
@@ -129,7 +129,7 @@ export const EventCard: React.FC<EventCardProps> = ({
   return (
     <>
       <AnimatePresence mode="popLayout">
-        <Link href={`/event/${event.id}/${event.year}`}>
+        <Link href={`/event/${event.id}/${event.year}/register`}>
           <motion.div
             key={`${event.id + event.year + event.createdAt}`}
             layout

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { getCurrentUser } from "@aws-amplify/auth/server";
+import { fetchUserAttributes } from "@aws-amplify/auth/server";
 import { runWithAmplifyServerContext } from "./util/amplify-utils";
 
 export async function middleware(request: NextRequest) {
@@ -26,8 +26,7 @@ export async function middleware(request: NextRequest) {
       nextServerContext: { request, response },
       operation: async (contextSpec) => {
         try {
-          const { signInDetails } = await getCurrentUser(contextSpec);
-          const email = signInDetails?.loginId;
+          const { email } = await fetchUserAttributes(contextSpec);
           return (
             email &&
             email.substring(email.indexOf("@") + 1, email.length) ===


### PR DESCRIPTION
## Describe your changes
- getUserAttributes appears to have been deprecated by amplify/auth/server package
- changed to use fetchUserAttributes, consistent with rest of frontend
- made event dashboard actually link to the event registration page

### Testing
debugged with @ahosseini06 

<img width="164" height="34" alt="image" src="https://github.com/user-attachments/assets/75ea2a6d-e6a0-4bf1-89f7-0cec48a68189" />

_continually printed undefined, preventing access to admin pages due to middleware._
_after some fixes you can see the correct user email is available_

<img width="516" height="228" alt="image" src="https://github.com/user-attachments/assets/f4164bbb-a1c4-4dde-b120-b3eb3cdcbd73" />

_event dashboard actually working_
<video src="https://github.com/user-attachments/assets/14204d37-7c6a-4cbd-803e-b3e0fbd77160" width=300/>


