### PR TITLE
Fix login flow

### DIFF
--- a/src/components/ProfilePage/EditProfileForm.tsx
+++ b/src/components/ProfilePage/EditProfileForm.tsx
@@ -17,7 +17,14 @@ export const profileFormSchema = z.object({
   hobby2: z.string().optional(),
   funQuestion1: z.string().optional(),
   funQuestion2: z.string().optional(),
-  linkedIn: z.string().url("LinkedIn URL must be a valid URL").optional(),
+  linkedIn: z
+    .string()
+    .optional()
+    .refine(
+      (val) =>
+        !val || val.trim() === "" || z.string().url().safeParse(val).success,
+      { message: "LinkedIn URL must be a valid URL" },
+    ),
   profilePictureURL: z
     .string()
     .url("Profile picture URL must be a valid URL")
@@ -41,11 +48,15 @@ interface ProfileFormSchema extends z.infer<typeof profileFormSchema> {}
 interface NFCProfilePageProps {
   profileData: Partial<ProfileFormSchema>;
   error?: string;
+  setProfileData: (data: any) => void;
+  onFinishEdit?: () => void;
 }
 
 export const EditProfileForm: React.FC<NFCProfilePageProps> = ({
   profileData,
   error,
+  setProfileData,
+  onFinishEdit,
 }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -81,7 +92,8 @@ export const EditProfileForm: React.FC<NFCProfilePageProps> = ({
           title: "Success",
           description: "Profile updated successfully!",
         });
-        form.reset(data);
+        setProfileData({ ...profileData, ...data });
+        if (onFinishEdit) onFinishEdit();
       }
     } catch (error) {
       toast({

--- a/src/components/ProfilePage/EditProfilePage.tsx
+++ b/src/components/ProfilePage/EditProfilePage.tsx
@@ -62,9 +62,10 @@ interface ProfileUpdateForm {
 }
 
 export const EditProfilePage = ({
-  profileData,
+  profileData: initialProfileData,
   error,
 }: NFCProfilePageProps) => {
+  const [profileData, setProfileData] = useState(initialProfileData);
   const [isDrawerOpen, setDrawerOpen] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -289,7 +290,11 @@ export const EditProfilePage = ({
 
       <div className="flex flex-col justify-center col-span-2 space-y-6 w-full">
         {isEditing ? (
-          <EditProfileForm profileData={profileData} />
+          <EditProfileForm
+            profileData={profileData}
+            setProfileData={setProfileData}
+            onFinishEdit={() => setIsEditing(false)}
+          />
         ) : (
           <>
             {/* Display Mode - Original Profile View */}
@@ -304,8 +309,12 @@ export const EditProfilePage = ({
                     <div className="inline-flex flex-wrap items-center gap-2">
                       <span className="text-sm text-pale-blue">Hobbies:</span>
                       <div className="flex flex-wrap gap-2">
-                        {hobby1 && <HobbyTag hobby={hobby1} />}
-                        {hobby2 && <HobbyTag hobby={hobby2} />}
+                        {hobby1 && profileData.viewableMap.hobby1 && (
+                          <HobbyTag hobby={hobby1} />
+                        )}
+                        {hobby2 && profileData.viewableMap.hobby1 && (
+                          <HobbyTag hobby={hobby2} />
+                        )}
                       </div>
                     </div>
                     <div className="border-border-blue border-[0.5px]" />

--- a/src/components/SignUpForm/FormInput.tsx
+++ b/src/components/SignUpForm/FormInput.tsx
@@ -71,6 +71,7 @@ export const FormInput = React.forwardRef<HTMLInputElement, FormInputProps>(
           )}
           ref={ref}
           {...field}
+          {...props}
         />
       </FormControl>
       <FormMessage />

--- a/src/hooks/useRedirect.ts
+++ b/src/hooks/useRedirect.ts
@@ -29,6 +29,7 @@ export function useRedirect() {
         if (pathname === "/") {
           router.replace("/login");
         }
+        setLoading(false);
       }
     }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -33,10 +33,6 @@ const ProfilePage: React.FC<ProfilePageProps> = ({
 }) => {
   const router = useRouter();
 
-  if (!profile) {
-    router.push("/login");
-  }
-
   function getEventState(event: BiztechEvent | null) {
     return event && toDate(event.startDate) < toDate(new Date())
       ? "Past"
@@ -165,13 +161,10 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       };
     }
 
-    // Optionally handle other errors
     return {
-      props: {
-        profile: null,
-        events: [],
-        registrations: [],
-        highlightedEvent: null,
+      redirect: {
+        destination: "/login",
+        permanent: false,
       },
     };
   }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { BiztechEvent, User } from "@/types";
-import { fetchBackend } from "@/lib/db";
+import { fetchBackendFromServer } from "@/lib/db";
 import { fetchUserAttributes } from "@aws-amplify/auth";
 import { Registration } from "@/types/types";
 import Divider from "@/components/Common/Divider";
@@ -16,94 +16,31 @@ import { useRouter } from "next/navigation";
 import { useRedirect } from "@/hooks/useRedirect";
 import { Spinner } from "@/components/ui/spinner";
 import PageLoadingState from "@/components/Common/PageLoadingState";
+import { GetServerSideProps } from "next";
 
-const fetchProfileData = async (email: string) => {
-  const profileData = await fetchBackend({
-    endpoint: `/users/${email}`,
-    method: "GET",
-    authenticatedCall: true,
-  });
+interface ProfilePageProps {
+  profile: User | null;
+  events: BiztechEvent[];
+  registrations: Registration[];
+  highlightedEvent: BiztechEvent | null;
+}
 
-  return profileData;
-};
-
-const fetchAllEvents = async () => {
-  const events = await fetchBackend({
-    endpoint: `/events`,
-    method: "GET",
-    authenticatedCall: false,
-  });
-
-  const allEvents = events.filter(
-    (event: BiztechEvent) =>
-      toDate(event.startDate) > toDate(new Date(2024, 9, 1)),
-  );
-
-  return allEvents;
-};
-
-const fetchAttendedEvents = async (email: string) => {
-  const userRegistrations = await fetchBackend({
-    endpoint: `/registrations/?email=${email}`,
-    method: "GET",
-    authenticatedCall: false,
-  });
-
-  return userRegistrations;
-};
-
-const ProfilePage = () => {
-  const [loading, setIsLoading] = useState(true);
-  const [events, setEvents] = useState<BiztechEvent[]>([]);
-  const [registrations, setRegistrations] = useState<Registration[]>([]);
-  const [highlightedEvent, setHighlightedEvent] = useState<BiztechEvent | null>(
-    null,
-  );
-  const [profile, setProfile] = useState<User | null>(null);
-
+const ProfilePage: React.FC<ProfilePageProps> = ({
+  profile,
+  events,
+  registrations,
+  highlightedEvent,
+}) => {
   const router = useRouter();
 
-  const authLoading = useRedirect();
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const attributes = await fetchUserAttributes();
-
-        const email = attributes.email;
-        if (!email) {
-          throw new Error("No email found");
-        }
-
-        const [profileData, allEvents, userRegistrations] = await Promise.all([
-          fetchProfileData(email),
-          fetchAllEvents(),
-          fetchAttendedEvents(email),
-        ]);
-
-        const highlightedEventResult = getHighlightedEvent(allEvents);
-
-        setProfile(profileData);
-        setEvents(allEvents);
-        setHighlightedEvent(highlightedEventResult);
-        setRegistrations(userRegistrations.data);
-        setIsLoading(false);
-      } catch (err) {
-        console.error("Failed to fetch user profile data:", err);
-      }
-    };
-
-    fetchData();
-  }, []);
+  if (!profile) {
+    router.push("/login");
+  }
 
   function getEventState(event: BiztechEvent | null) {
     return event && toDate(event.startDate) < toDate(new Date())
       ? "Past"
       : "Upcoming";
-  }
-
-  if (loading || authLoading) {
-    return <PageLoadingState />;
   }
 
   return (
@@ -176,6 +113,68 @@ const ProfilePage = () => {
       </div>
     </div>
   );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const nextServerContext = { request: context.req, response: context.res };
+
+  try {
+    const profile = await fetchBackendFromServer({
+      endpoint: `/users/self`,
+      method: "GET",
+      nextServerContext,
+    });
+
+    const events = await fetchBackendFromServer({
+      endpoint: `/events`,
+      method: "GET",
+      authenticatedCall: false,
+      nextServerContext,
+    });
+
+    // 3. Fetch registrations for this user
+    const registrationsRes = await fetchBackendFromServer({
+      endpoint: `/registrations/?email=${profile.email}`,
+      method: "GET",
+      authenticatedCall: false,
+      nextServerContext,
+    });
+
+    // 4. Filter and highlight events
+    const allEvents = events.filter(
+      (event: BiztechEvent) =>
+        toDate(event.startDate) > toDate(new Date(2024, 9, 1)),
+    );
+    const highlightedEvent = getHighlightedEvent(allEvents);
+
+    return {
+      props: {
+        profile,
+        events: allEvents,
+        registrations: registrationsRes.data,
+        highlightedEvent: highlightedEvent || null,
+      },
+    };
+  } catch (err: any) {
+    if (err.status === 404) {
+      return {
+        redirect: {
+          destination: "/membership",
+          permanent: false,
+        },
+      };
+    }
+
+    // Optionally handle other errors
+    return {
+      props: {
+        profile: null,
+        events: [],
+        registrations: [],
+        highlightedEvent: null,
+      },
+    };
+  }
 };
 
 export default ProfilePage;

--- a/src/pages/membership.tsx
+++ b/src/pages/membership.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { Amplify } from "aws-amplify";
-import { fetchUserAttributes } from "@aws-amplify/auth";
+import { fetchUserAttributes, signOut } from "@aws-amplify/auth";
 import * as Yup from "yup";
 import { useForm, FormProvider, Controller } from "react-hook-form";
 import outputs from "../../amplify_outputs.json";
@@ -209,6 +209,15 @@ const Membership = () => {
                 <Link
                   href="/login"
                   className="text-sm leading-6 text-biztech-green underline"
+                  onClick={async (e) => {
+                    e.preventDefault();
+
+                    try {
+                      await signOut();
+                    } catch (error) {
+                      console.error("error signing in", error);
+                    }
+                  }}
                 >
                   Back to Login Page
                 </Link>

--- a/src/pages/membership.tsx
+++ b/src/pages/membership.tsx
@@ -131,11 +131,12 @@ const Membership = () => {
             method: "POST",
             data: userBody,
           }),
-          fetchBackend({
-            endpoint: "/profiles",
-            method: "POST",
-          }),
         ]);
+
+        await fetchBackend({
+          endpoint: "/profiles",
+          method: "POST",
+        });
         router.push(`/`);
       } else {
         const paymentBody = {

--- a/src/pages/membership.tsx
+++ b/src/pages/membership.tsx
@@ -52,13 +52,14 @@ const Membership = () => {
         }
       } catch (error) {
         console.error("Failed to fetch user attributes:", error);
+        router.push(`/login`);
       } finally {
         setLoading(false);
       }
     };
 
     getUserEmail();
-  }, []);
+  }, [router]);
 
   const validationSchema = Yup.object({
     firstName: Yup.string().required("First name is required"),
@@ -103,12 +104,39 @@ const Membership = () => {
 
     try {
       if (userBody.admin) {
-        await fetchBackend({
-          endpoint: "/users",
-          method: "POST",
-          data: userBody,
-        });
-        router.push(`/signup/success/UserMember/${email}`);
+        await Promise.all([
+          fetchBackend({
+            endpoint: "/members",
+            method: "POST",
+            data: {
+              email: userBody.email,
+              education: userBody.education,
+              first_name: userBody.fname,
+              last_name: userBody.lname,
+              pronouns: userBody.gender,
+              student_number: userBody.studentId,
+              faculty: userBody.faculty,
+              year: userBody.year,
+              major: userBody.major,
+              prev_member: userBody.prev_member,
+              international: userBody.international,
+              topics: topicsString,
+              heard_from: values.referral,
+              diet: userBody.diet,
+              admin: userBody.admin,
+            },
+          }),
+          fetchBackend({
+            endpoint: "/users",
+            method: "POST",
+            data: userBody,
+          }),
+          fetchBackend({
+            endpoint: "/profiles",
+            method: "POST",
+          }),
+        ]);
+        router.push(`/`);
       } else {
         const paymentBody = {
           paymentName: "BizTech Membership",
@@ -419,7 +447,9 @@ const Membership = () => {
               className="rounded-md bg-indigo-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400"
               disabled={isSubmitting}
             >
-              Proceed to Payment
+              {email.toLowerCase().endsWith("@ubcbiztech.com")
+                ? "Create Membership"
+                : "Proceed to Payment"}
             </button>
           </div>
         </form>


### PR DESCRIPTION
## Describe your changes
- moved login, sign up flow to request using SSR (describes flow in notes)
- updated home page to use SSR
- small edit form bug fixes (improved type validation, enabled small props to be added

## Notes
1. login email/pw flow
- uses amplify to sign in, checks if user exists, and if isMember field is false OR the row doesnt exist it sends users to memberships (we need to fix this one case in the backend still @bennypc because it doesn't update the column after a payment at the moment)
- otherwise sends to home pagepp
2. login oauth flow
- similar to above
3. sign up email/pw flow
- sends verification email, redirects to verifcation before allowing users to sign in
4. sign up oauth flow
- skips directly to sign in since provider is external, and user, member and profile rows will be created after payment

_notably, all of these changes are made with the assumption that all users must be members to register_

## Checklist before requesting a review
- [x] I have performed a self-review of my code

## Images / Video of Feature
PW sign up

https://github.com/user-attachments/assets/7c7e581e-ec18-4e2e-9d65-5ecec98919dc


Oauth sign up

https://github.com/user-attachments/assets/0e80fd42-bf29-4a45-a171-896368b2afb3

