### PR TITLE
fix: make registrations data page available on mobile

### DIFF
--- a/src/components/EventCard/mobileEventCard.tsx
+++ b/src/components/EventCard/mobileEventCard.tsx
@@ -21,6 +21,7 @@ type Props = {
 };
 
 const editEventPopupItems: PopUpItem[] = [
+  PopUpItem.ViewRegistrations,
   PopUpItem.EditEvent,
   PopUpItem.ViewAsMember,
   PopUpItem.DeleteEvent,

--- a/src/components/EventCard/popup/editPopUp.tsx
+++ b/src/components/EventCard/popup/editPopUp.tsx
@@ -23,6 +23,9 @@ const PopupModal = forwardRef<HTMLDivElement, PopupModalProps>(
         case PopUpItem.ViewAsMember:
           modalHandlers.handleViewAsMember(eventID, eventYear);
           break;
+        case PopUpItem.ViewRegistrations:
+          modalHandlers.handleViewRegistrations(eventID, eventYear);
+          break;
         default:
           console.log(`${item} button clicked`);
           break;

--- a/src/components/EventCard/popup/mobileEditPopUp.tsx
+++ b/src/components/EventCard/popup/mobileEditPopUp.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import DeletePopup from "./deletePopUp";
 import { BiztechEvent } from "@/types/types";
 import { ModalHandlers } from "@/pages/admin/home";
+import { PopUpItem } from "../types";
 
 type Props = {
   isClicked: boolean;
@@ -14,13 +15,8 @@ type Props = {
   modalHandlers: ModalHandlers;
 };
 
-const enum PopUpItem {
-  EditEvent = "Edit Event",
-  ViewAsMember = "View as Member",
-  DeleteEvent = "Delete Event",
-}
-
 const editEventPopupItems: String[] = [
+  PopUpItem.ViewRegistrations,
   PopUpItem.EditEvent,
   PopUpItem.ViewAsMember,
   PopUpItem.DeleteEvent,
@@ -36,6 +32,9 @@ export default function MobilePopup({
 }: Props) {
   const handleButtonClick = (item: String) => {
     switch (item) {
+      case PopUpItem.ViewRegistrations:
+        modalHandlers.handleViewRegistrations(event.id, event.year);
+        break;
       case PopUpItem.DeleteEvent:
         modalHandlers.handleEventDelete();
         break;

--- a/src/components/EventCard/types.ts
+++ b/src/components/EventCard/types.ts
@@ -1,4 +1,5 @@
 export const enum PopUpItem {
+  ViewRegistrations = "View Registrations",
   EditEvent = "Edit Event",
   ViewAsMember = "View as Member",
   DeleteEvent = "Delete Event",

--- a/src/pages/admin/home.tsx
+++ b/src/pages/admin/home.tsx
@@ -18,6 +18,7 @@ export type ModalHandlers = {
   handleEventDelete: () => void;
   handleEditEvent: () => void;
   handleViewAsMember: (eventID: string, eventYear: number) => void;
+  handleViewRegistrations: (eventID: string, eventYear: number) => void;
 };
 
 export default function AdminEventView({ events }: Props) {
@@ -40,6 +41,10 @@ export default function AdminEventView({ events }: Props) {
 
   const handleViewAsMember = (eventID: string, eventYear: number) => {
     router.push(`/event/${eventID}/${eventYear}/register`);
+  };
+
+  const handleViewRegistrations = (eventID: string, eventYear: number) => {
+    router.push(`/admin/event/${eventID}/${eventYear}`);
   };
 
   // Update event click to navigate to registration table view
@@ -130,6 +135,7 @@ export default function AdminEventView({ events }: Props) {
                   event={event}
                   eventClick={eventClick}
                   modalHandlers={{
+                    handleViewRegistrations: handleViewRegistrations,
                     handleEventDelete: handleEventDelete,
                     handleEditEvent: () =>
                       router.push(
@@ -150,6 +156,7 @@ export default function AdminEventView({ events }: Props) {
                 event={event}
                 eventClick={mobileEventClick}
                 modalHandlers={{
+                  handleViewRegistrations: handleViewRegistrations,
                   handleEventDelete: handleEventDelete,
                   handleEditEvent: () =>
                     router.push(`/admin/event/${event.id}/${event.year}/edit`),
@@ -165,7 +172,7 @@ export default function AdminEventView({ events }: Props) {
         <div
           className={
             isClicked && (isMobileDevice || isDelete)
-              ? "fixed inset-0 flex items-center justify-center z-50 bg-bt-blue-700 bg-opacity-50 blur-background"
+              ? "fixed inset-0 flex items-center justify-center z-50 bg-bt-blue-700/50 bg-opacity-50 backdrop-blur-md"
               : ""
           }
         >
@@ -176,6 +183,7 @@ export default function AdminEventView({ events }: Props) {
             event={event!}
             setIsDelete={setIsDelete}
             modalHandlers={{
+              handleViewRegistrations: handleViewRegistrations,
               handleEventDelete: handleEventDelete,
               handleEditEvent: handleEditEvent,
               handleViewAsMember: handleViewAsMember,


### PR DESCRIPTION
## Describe your changes

Popup logic made it impossible to access the admin data page on mobile, fixed to add a "View Registrations" option in the popup

## Images / Video of Feature

https://github.com/user-attachments/assets/7fe3a77d-e93e-41d8-a439-f5363a7fef08

