### PR TITLE
Fix logout redirect

### DIFF
--- a/src/components/NavBar/NavbarTab.tsx
+++ b/src/components/NavBar/NavbarTab.tsx
@@ -43,7 +43,7 @@ const NavbarTab: React.FC<NavbarProps> = ({
       onLogout?.();
       onTabClick?.();
 
-      router.replace("/sign-in");
+      router.replace("/login");
     } catch (error) {
       console.error("Error signing out:", error);
       setIsSigningOut(false);


### PR DESCRIPTION
## Describe your changes


* Changed Logout from `Link` to `button`.
* Use `signOut({ global: true })` then `router.replace("/sign-in")`.
* Ensures user always lands on sign-in after logout, no stale state.

## Checklist before requesting a review

- [x] I have performed a self-review of my code