### PR TITLE
Fix infinite re-renders

### DIFF
--- a/src/components/RegistrationTable/NFCCardCell.tsx
+++ b/src/components/RegistrationTable/NFCCardCell.tsx
@@ -45,7 +45,7 @@ export const NFCCardCell: React.FC<NFCCardCellProps> = ({
     };
 
     checkCardStatus();
-  }, [email, checkUserNeedsCard]);
+  }, [email]);
 
   const handleWriteToCard = () => {
     setShowNfcWriter(true);


### PR DESCRIPTION
fixing infinite re renders in of tableCell by removing checkUserNeedsCard from the dependency array of the useEffect that checks whether a user needs a card on mounting of tableCell
