### PR TITLE
Fix infinite loop on memberships page

### DIFF
--- a/src/pages/membership.tsx
+++ b/src/pages/membership.tsx
@@ -126,7 +126,6 @@ const Membership: React.FC = () => {
         setEmail(userEmail);
         methods.setValue("email", userEmail);
       } catch (error) {
-        console.log(error);
         // Treat any error as unauthenticated -> go to login
         if (!hasRedirectedRef.current) {
           hasRedirectedRef.current = true;


### PR DESCRIPTION
## Describe your changes
We should only redirect to login from membership if it's a COGNITO error NOT a 404 on `/users/self` endpoint
For the latter, it will cause an infinite loop because login will redirect back to membership when it detects that user is logged in, and so on and so forth

## Issue ticket number and link
-

## Checklist before requesting a review

- [ ] I have performed a self-review of my code

## Images / Video of Feature
BEFORE:

https://github.com/user-attachments/assets/de2fd67d-c221-458e-969d-6353ec7adf0f

AFTER:

https://github.com/user-attachments/assets/855bd5f4-83b6-47a2-b61e-ac26b5777be8


