### PR TITLE
[Kickstart] Fix non-members event display

### DIFF
--- a/src/components/EventsDashboard/EventCard.tsx
+++ b/src/components/EventsDashboard/EventCard.tsx
@@ -121,8 +121,10 @@ export const EventCard: React.FC<EventCardProps> = ({
         : "Free!"
     } ` +
     `${
-      event.pricing?.nonMembers
+      event.pricing?.nonMembers > 0
         ? `(Non-members ${event.pricing?.nonMembers.toFixed(2)})`
+        : event.pricing?.nonMembers === 0
+        ? "(Non-members Free!)"
         : "(Members only)"
     }`;
 


### PR DESCRIPTION
0 is falsy, which is why it will display members only even though it's not