### PR TITLE
UBC-16: feat: manual event registration

### DIFF
--- a/src/components/RegistrationTable/AddAttendeeDialog.tsx
+++ b/src/components/RegistrationTable/AddAttendeeDialog.tsx
@@ -1,0 +1,164 @@
+import React, { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+import { fetchBackend } from "@/lib/db";
+import { EMAIL_REGEX } from "@/constants/registrations";
+import { DBRegistrationStatus } from "@/types";
+import { ApplicationStatus } from "@/types";
+
+interface AddAttendeeDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  eventId: string;
+  year: string;
+  refreshTable: () => Promise<void>;
+}
+
+export const AddAttendeeDialog: React.FC<AddAttendeeDialogProps> = ({
+  open,
+  onOpenChange,
+  eventId,
+  year,
+  refreshTable,
+}) => {
+  const { toast } = useToast();
+  const [addEmail, setAddEmail] = useState("");
+  const [addFname, setAddFname] = useState("");
+  const [addLname, setAddLname] = useState("");
+  const [addError, setAddError] = useState<string | null>(null);
+  const [isAddSubmitting, setIsAddSubmitting] = useState(false);
+
+  const handleAddAttendee = async () => {
+    const email = addEmail.trim().toLowerCase();
+    if (!EMAIL_REGEX.test(email)) {
+      setAddError("A valid email is required.");
+      return;
+    }
+    if (!addFname.trim()) {
+      setAddError("First name is required.");
+      return;
+    }
+    setIsAddSubmitting(true);
+    setAddError(null);
+    try {
+      await fetchBackend({
+        endpoint: "/registrations",
+        method: "POST",
+        data: {
+          email,
+          fname: addFname.trim(),
+          basicInformation: {
+            fname: addFname.trim(),
+            ...(addLname.trim() && { lname: addLname.trim() }),
+          },
+          eventID: eventId,
+          year: Number(year),
+          registrationStatus: DBRegistrationStatus.REGISTERED,
+          applicationStatus: ApplicationStatus.REVIEWING,
+        },
+        authenticatedCall: true,
+      });
+      onOpenChange(false);
+      setAddEmail("");
+      setAddFname("");
+      setAddLname("");
+      await refreshTable();
+      toast({
+        title: "Attendee added",
+        description: `${email} has been registered.`,
+      });
+    } catch (err: any) {
+      const message = err?.message?.message || err?.message;
+      setAddError(
+        typeof message === "string" ? message : "Failed to add attendee.",
+      );
+    } finally {
+      setIsAddSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        onOpenChange(isOpen);
+        if (!isOpen) {
+          setAddError(null);
+          setAddEmail("");
+          setAddFname("");
+          setAddLname("");
+        }
+      }}
+    >
+      <DialogContent className="max-w-md w-full bg-bt-blue-400">
+        <DialogHeader>
+          <DialogTitle className="text-white">Add Attendee</DialogTitle>
+        </DialogHeader>
+
+        <div className="w-full h-[1px] bg-[#8DA1D1] my-3" />
+
+        <div className="space-y-4">
+          {addError && (
+            <div className="bg-red-500/20 border border-red-500/50 text-red-300 px-3 py-2 rounded text-sm">
+              {addError}
+            </div>
+          )}
+          <div>
+            <Label htmlFor="addEmail" className="text-white">
+              Email *
+            </Label>
+            <Input
+              id="addEmail"
+              value={addEmail}
+              onChange={(e) => setAddEmail(e.target.value)}
+              placeholder="attendee@example.com"
+              className="bg-bt-blue-400 text-white border-[#8DA1D1]"
+            />
+          </div>
+          <div>
+            <Label htmlFor="addFname" className="text-white">
+              First Name *
+            </Label>
+            <Input
+              id="addFname"
+              value={addFname}
+              onChange={(e) => setAddFname(e.target.value)}
+              placeholder="First name"
+              className="bg-bt-blue-400 text-white border-[#8DA1D1]"
+            />
+          </div>
+          <div>
+            <Label htmlFor="addLname" className="text-white">
+              Last Name
+            </Label>
+            <Input
+              id="addLname"
+              value={addLname}
+              onChange={(e) => setAddLname(e.target.value)}
+              placeholder="Last name (optional)"
+              className="bg-bt-blue-400 text-white border-[#8DA1D1]"
+            />
+          </div>
+        </div>
+
+        <div className="w-full h-[1px] bg-[#8DA1D1] my-3" />
+
+        <Button
+          onClick={handleAddAttendee}
+          className="text-bt-blue-400 bg-bt-green-300"
+          disabled={isAddSubmitting}
+        >
+          {isAddSubmitting ? "Adding..." : "Add Attendee"}
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/RegistrationTable/TableHeader.tsx
+++ b/src/components/RegistrationTable/TableHeader.tsx
@@ -24,6 +24,7 @@ import {
 import { Filter, Search, Download, Copy, Check } from "lucide-react";
 import { TableFilterButtons } from "./TableFilterButtons";
 import { TableIconButtons } from "./TableIconButtons";
+import { AddAttendeeDialog } from "./AddAttendeeDialog";
 import { Table } from "@tanstack/react-table";
 import {
   Dialog,
@@ -78,6 +79,7 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
 }) => {
   const selectedRowsCount = Object.keys(rowSelection).length;
   const [showMassUpdateStatus, setShowMassUpdateStatus] = useState(false);
+  const [showAddAttendee, setShowAddAttendee] = useState(false);
   const [showCreateTeam, setShowCreateTeam] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [newStatus, setNewStatus] = useState("");
@@ -357,6 +359,14 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
       </div>
 
       <div className="flex flex-col sm:flex-row items-center justify-between space-x-2 mt-4 lg:mt-0">
+        <Button
+          className="text-bt-blue-400 bg-bt-green-300 mr-2"
+          onClick={() => {
+            setShowAddAttendee(true);
+          }}
+        >
+          + Add Attendee
+        </Button>
         <Select value={selectedValue} onValueChange={handleSelectChange}>
           <SelectTrigger className="w-[180px] bg-bt-blue-400 text-white">
             <SelectValue placeholder="Attendees" />
@@ -481,6 +491,14 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
           </Button>
         </DialogContent>
       </Dialog>
+
+      <AddAttendeeDialog
+        open={showAddAttendee}
+        onOpenChange={setShowAddAttendee}
+        eventId={eventId}
+        year={year}
+        refreshTable={refreshTable}
+      />
 
       <Dialog open={showCreateTeam} onOpenChange={setShowCreateTeam}>
         <DialogContent className="max-w-md w-full bg-bt-blue-400">


### PR DESCRIPTION
adds an "Add Attendee" button to the table header on the admin event registrations page. clicking it opens a modal with three fields — email (required), first name (required), last name (optional). on submit it posts to the existing POST /registrations endpoint.

a few specific choices worth noting:

registrationStatus is hardcoded to "registered" rather than exposing a dropdown. the backend already handles downgrading to waitlist if the event is at capacity, so there's no reason to make the admin choose
applicationStatus is set to "reviewing" to match what the db expects for a manually added entry
fname is written both at the top level (required by the backend for QR code ID generation) and nested under basicInformation (required by the frontend table columns which read from basicInformation.fname/lname)
no backend changes needed, the existing handler covers this case
Issue ticket number and link:

UBC-16 — https://linear.app/ubc-biztech/issue/UBC-16/manual-registration-form-in-event-page


https://github.com/user-attachments/assets/92613b8e-8e6d-40e5-819f-406546400e17

