### PR TITLE
CI: Check prettier formatting on PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,38 @@
+name: PR Rules
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  pr-rules:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: commits } = await github.rest.pulls.listCommits({
+              ...context.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            if (commits.length !== 1) {
+              core.setFailed(`PR must have exactly 1 commit (has ${commits.length})`);
+            }
+
+            const msg = commits[0].commit.message;
+            const [subject, ...bodyLines] = msg.split('\n');
+
+            if (subject.length > 60) {
+              core.setFailed(`Commit subject must be ≤60 characters (got ${subject.length})`);
+            }
+
+            for (let i = 0; i < bodyLines.length; i++) {
+              const line = bodyLines[i];
+              if (line.length > 72) {
+                core.setFailed(`Commit body line ${i + 1} exceeds 72 characters: "${line.slice(0, 80)}..."`);
+              }
+            }

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,4 +1,4 @@
-name: autofix.ci
+name: Format
 
 on:
   pull_request:
@@ -27,8 +27,4 @@ jobs:
 
       - run: npm ci
 
-      - run: npx prettier . --write
-
-      - uses: autofix-ci/action@551dded8c6cc8a1054039c8bc0b8b48c51dfc6ef
-        with:
-          commit-message: "Formatting with Prettier"
+      - run: npx prettier . --check


### PR DESCRIPTION
Runs npx prettier --check on every PR push to validate code quality without auto-fixing. Developers fix formatting locally. Also enforces commit conventions: subject ≤60 chars, body lines ≤72 chars, exactly one commit per PR.