### PR TITLE
Fix event form input focus

### DIFF
--- a/src/components/Events/EventForm.tsx
+++ b/src/components/Events/EventForm.tsx
@@ -37,6 +37,25 @@ interface EventFormProps {
   eventYear?: string; // Add this prop for constructing URLs
 }
 
+const SectionCard: React.FC<{
+  icon: React.ReactNode;
+  title: string;
+  children: React.ReactNode;
+  className?: string;
+}> = ({ icon, title, children, className = "" }) => (
+  <div
+    className={`rounded-xl border border-bt-blue-300/30 bg-bt-blue-500/40 p-5 space-y-4 ${className}`}
+  >
+    <div className="flex items-center gap-2.5">
+      <span className="text-bt-green-300">{icon}</span>
+      <h4 className="text-sm font-semibold text-white tracking-wide uppercase">
+        {title}
+      </h4>
+    </div>
+    {children}
+  </div>
+);
+
 export const EventForm: React.FC<EventFormProps> = ({
   initialData,
   onSubmit,
@@ -157,25 +176,6 @@ export const EventForm: React.FC<EventFormProps> = ({
       };
     }
   };
-
-  const SectionCard: React.FC<{
-    icon: React.ReactNode;
-    title: string;
-    children: React.ReactNode;
-    className?: string;
-  }> = ({ icon, title, children, className = "" }) => (
-    <div
-      className={`rounded-xl border border-bt-blue-300/30 bg-bt-blue-500/40 p-5 space-y-4 ${className}`}
-    >
-      <div className="flex items-center gap-2.5">
-        <span className="text-bt-green-300">{icon}</span>
-        <h4 className="text-sm font-semibold text-white tracking-wide uppercase">
-          {title}
-        </h4>
-      </div>
-      {children}
-    </div>
-  );
 
   return (
     <div className="text-white px-4 py-6 sm:px-6 lg:px-8 max-w-[1600px] mx-auto w-full">


### PR DESCRIPTION
## What changed

- Moved `SectionCard` to module scope so its component identity stays stable across `EventForm` renders.

## Why

Typing in the watched event slug re-rendered `EventForm`. Because `SectionCard` was declared inside the form component, React treated it as a new component type and remounted the section after every character, dropping input focus.

## Impact

The event slug field now keeps focus while typing. The same root fix also prevents unnecessary remounts in the other event form sections.

## Validation

- `npm run lint` (passes with pre-existing warnings)
- `npm run build` (compiles and type-checks successfully; later page-data collection hits a pre-existing Node/Recharts module-loader assertion on `/btx`)
- AutoReview: clean, no accepted/actionable findings
