### PR TITLE
Prevent negative event values

### DIFF
--- a/src/components/Events/EventForm.tsx
+++ b/src/components/Events/EventForm.tsx
@@ -337,7 +337,12 @@ export const EventForm: React.FC<EventFormProps> = ({
                     label="Event Slug (URL)*"
                     disabled={!!initialData}
                   />
-                  <FormInput name="capacity" label="Capacity*" type="number" />
+                  <FormInput
+                    name="capacity"
+                    label="Capacity*"
+                    type="number"
+                    min={1}
+                  />
                 </div>
                 <div className="rounded-lg bg-bt-blue-600/60 border border-bt-blue-300/20 px-3 py-2 text-xs text-bt-blue-100 space-y-0.5">
                   <div className="flex items-center gap-1.5 text-bt-green-300 font-medium mb-1">
@@ -384,7 +389,12 @@ export const EventForm: React.FC<EventFormProps> = ({
                 title="Pricing"
               >
                 <div className="space-y-4">
-                  <FormInput name="price" label="Member Price" type="number" />
+                  <FormInput
+                    name="price"
+                    label="Member Price"
+                    type="number"
+                    min={0}
+                  />
                   {!nonBizTechAllowed && (
                     <p className="text-sm text-bt-blue-100">
                       Enable &quot;Non-BizTech members allowed?&quot; above to
@@ -396,6 +406,7 @@ export const EventForm: React.FC<EventFormProps> = ({
                       name="nonMemberPrice"
                       label="Non-Member Price"
                       type="number"
+                      min={0}
                     />
                   )}
                 </div>

--- a/src/components/Events/EventFormSchema.ts
+++ b/src/components/Events/EventFormSchema.ts
@@ -20,8 +20,11 @@ export const eventFormSchema = z.object({
   partnerDescription: z.string().min(1, "Partner description is required"),
 
   // Optional fields
-  price: z.number().default(0),
-  nonMemberPrice: z.number().optional(),
+  price: z.number().min(0, "Price cannot be negative").default(0),
+  nonMemberPrice: z
+    .number()
+    .min(0, "Non-member price cannot be negative")
+    .optional(),
   isApplicationBased: z.boolean().default(false),
   nonBizTechAllowed: z.boolean().default(false),
   isPublished: z.boolean().default(false),
@@ -43,9 +46,15 @@ export const eventFormSchema = z.object({
         question: z.string(),
         required: z.boolean(),
         options: z.array(z.string()),
-        charLimit: z.number().optional(),
+        charLimit: z
+          .number()
+          .min(0, "Character limit cannot be negative")
+          .optional(),
         questionImageUrl: z.string().optional(),
-        participantCap: z.number().optional(),
+        participantCap: z
+          .number()
+          .min(0, "Participant cap cannot be negative")
+          .optional(),
         isSkillsQuestion: z.boolean().optional(),
       }),
     )

--- a/src/components/Events/FormComponents/FormInput.tsx
+++ b/src/components/Events/FormComponents/FormInput.tsx
@@ -15,6 +15,7 @@ interface FormInputProps {
   placeholder?: string;
   type?: string;
   disabled?: boolean;
+  min?: number;
 }
 
 export const FormInput: React.FC<FormInputProps> = ({
@@ -23,6 +24,7 @@ export const FormInput: React.FC<FormInputProps> = ({
   placeholder,
   type = "text",
   disabled = false,
+  min,
 }) => {
   const { control } = useFormContext();
 
@@ -38,6 +40,7 @@ export const FormInput: React.FC<FormInputProps> = ({
               placeholder={placeholder || label}
               type={type}
               disabled={disabled}
+              min={min}
               {...field}
               onChange={(e) => {
                 const value =

--- a/src/components/Events/FormComponents/FormOptions.tsx
+++ b/src/components/Events/FormComponents/FormOptions.tsx
@@ -133,6 +133,7 @@ export const FormOptions: React.FC<FormOptionsProps> = ({
             <FormControl>
               <Input
                 type="number"
+                min={0}
                 {...register(`${name}.${index}.charLimit` as any, {
                   valueAsNumber: true,
                 })}


### PR DESCRIPTION
## What changed

- Added lower bounds to event capacity, member price, non-member price, and custom-question character-limit inputs.
- Added matching schema validation for prices, character limits, and participant caps.

## Why

The event form's numeric controls and schema allowed count-like and price values to become negative.

## Impact

Invalid negative values are blocked by the UI where possible and rejected by form validation before submission.

## Validation

- `npm run lint` (passes with pre-existing warnings)
- Focused schema checks for all four negative-value paths
- Prettier and `git diff --check`
- AutoReview: clean after fixing its participant-cap finding
