### PR TITLE
Allow empty partner descriptions

### DIFF
--- a/src/components/Events/EventForm.tsx
+++ b/src/components/Events/EventForm.tsx
@@ -420,7 +420,7 @@ export const EventForm: React.FC<EventFormProps> = ({
               >
                 <FormTextarea
                   name="partnerDescription"
-                  label="Partner Description*"
+                  label="Partner Description"
                 />
                 <CustomQuestions
                   control={form.control}

--- a/src/components/Events/EventFormSchema.ts
+++ b/src/components/Events/EventFormSchema.ts
@@ -17,7 +17,7 @@ export const eventFormSchema = z.object({
   deadline: z.date({
     required_error: "Registration deadline is required",
   }),
-  partnerDescription: z.string().min(1, "Partner description is required"),
+  partnerDescription: z.string().default(""),
 
   // Optional fields
   price: z.number().default(0),


### PR DESCRIPTION
## What changed

- Made partner description optional in the event form schema with an empty-string default.
- Removed the required marker from its label.

## Why

Create and edit payloads already send `partnerDescription` as a string and support `""`, but the frontend schema blocked saving unless the field contained text.

## Impact

Events without partner-specific copy can be saved while preserving the backend field.

## Validation

- Focused schema check confirms the field defaults to `""`
- `npm run lint` (passes with pre-existing warnings)
- Prettier and `git diff --check`
- AutoReview: clean, no accepted/actionable findings
