### PR TITLE
Show event validation errors when save is blocked

### DIFF
--- a/src/components/Events/EventForm.tsx
+++ b/src/components/Events/EventForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useForm, useWatch } from "react-hook-form";
+import { SubmitErrorHandler, useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
@@ -120,6 +120,23 @@ export const EventForm: React.FC<EventFormProps> = ({
     }
   };
 
+  const handleInvalidSubmit: SubmitErrorHandler<EventFormSchema> = (errors) => {
+    const firstError = Object.values(errors).find(
+      (error) => error && "message" in error && error.message,
+    );
+
+    toast({
+      title: "Unable to save event",
+      description:
+        firstError &&
+        "message" in firstError &&
+        typeof firstError.message === "string"
+          ? firstError.message
+          : "Please fix the highlighted fields and try again.",
+      variant: "destructive",
+    });
+  };
+
   const handlePublish = async () => {
     setIsSubmitting(true);
     try {
@@ -180,7 +197,10 @@ export const EventForm: React.FC<EventFormProps> = ({
   return (
     <div className="text-white px-4 py-6 sm:px-6 lg:px-8 max-w-[1600px] mx-auto w-full">
       <Form {...form}>
-        <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
+        <form
+          onSubmit={form.handleSubmit(handleSubmit, handleInvalidSubmit)}
+          className="space-y-6"
+        >
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
             <div className="flex items-center gap-3">
               <Link

--- a/src/components/Events/EventFormSchema.ts
+++ b/src/components/Events/EventFormSchema.ts
@@ -13,7 +13,7 @@ export const eventFormSchema = z.object({
     required_error: "End date is required",
   }),
   location: z.string().min(1, "Location is required"),
-  imageUrl: z.string().min(1, "Image URL is required"),
+  imageUrl: z.string().min(1, "Cover photo is required"),
   deadline: z.date({
     required_error: "Registration deadline is required",
   }),


### PR DESCRIPTION
## What changed
- show a destructive toast when Save is blocked by form validation
- surface the first validation message instead of failing silently
- call the required image field “Cover photo” to match the UI

## Why
The form only registered a valid-submit callback, so failed validation prevented submission without giving the user any top-level feedback. This was especially confusing for the custom cover-photo field.

## Verification
- `npx prettier --check src/components/Events/EventForm.tsx src/components/Events/EventFormSchema.ts`
- `npx eslint src/components/Events/EventForm.tsx src/components/Events/EventFormSchema.ts`
- `npx tsc --noEmit`
- AutoReview: clean (0.94 confidence)