### PR TITLE
Use squash merges for feature pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,27 +12,10 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
-            const { data: commits } = await github.rest.pulls.listCommits({
-              ...context.repo,
-              pull_number: context.payload.pull_request.number,
-            });
-            if (commits.length !== 1) {
-              core.setFailed(`PR must have exactly 1 commit (has ${commits.length})`);
-            }
-
-            const msg = commits[0].commit.message;
-            const [subject, ...bodyLines] = msg.split('\n');
-
-            if (subject.length > 60) {
-              core.setFailed(`Commit subject must be ≤60 characters (got ${subject.length})`);
-            }
-
-            for (let i = 0; i < bodyLines.length; i++) {
-              const line = bodyLines[i];
-              if (line.length > 72) {
-                core.setFailed(`Commit body line ${i + 1} exceeds 72 characters: "${line.slice(0, 80)}..."`);
-              }
+            const title = context.payload.pull_request.title;
+            if (title.length > 60) {
+              core.setFailed(`PR title must be ≤60 characters (got ${title.length})`);
             }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+## Branch and merge strategy
+
+- Open feature and fix pull requests against `dev`.
+- Feature and fix pull requests may contain multiple development commits. Use
+  **Squash and merge** so each pull request adds one commit to `dev`.
+- Open production release pull requests from `dev` to `main`. Use a regular
+  merge so the shared history between the long-lived branches is preserved.
+
+Pull request titles must be at most 60 characters because the title becomes the
+squashed commit subject.


### PR DESCRIPTION
## What changed

- Remove the requirement that every pull request already contain exactly one
  commit.
- Validate the pull request title instead, since it becomes the squash commit
  subject.
- Upgrade `actions/github-script` from v7 to v9 to remove the Node 20
  deprecation warning.
- Document the intended branch strategy:
  - feature/fix branches → `dev`: squash and merge
  - `dev` → `main`: regular merge

## Why

The one-commit check was written for feature pull requests but also runs on
release pull requests. PR #448 promotes `dev` to `main`, so it correctly
contains the accumulated feature commits and has failed this check since it
opened.

Squashing at merge keeps one commit per feature in `dev` without forcing
contributors to rewrite their working history. Preserving a regular merge from
`dev` to `main` keeps the long-lived branches related.

## Repository settings follow-up

This repository currently allows only rebase merges. An admin must enable
**Squash merging** for feature PRs and **Merge commits** for `dev` → `main`. A
branch ruleset should restrict PRs targeting `dev` to squash merges if strict
enforcement is desired.

## Validation

- Prettier 3.5.3 check passed for the changed files.
- Workflow YAML syntax check passed.
- `git diff --check` passed.
- Full `npm ci` is currently blocked by the pre-existing mismatch between
  `package.json` and `package-lock.json`; this PR does not change dependencies.
