### PR TITLE
[FIX]  Encoded emails not validating or decoding at backend

### DIFF
--- a/src/lib/membership.ts
+++ b/src/lib/membership.ts
@@ -5,7 +5,7 @@ export async function checkMembership(email: string): Promise<boolean> {
   const normalizedEmail = email.trim().toLowerCase();
 
   const hasMembership = await fetchBackend({
-    endpoint: `/users/checkMembership/${encodeURIComponent(normalizedEmail)}`,
+    endpoint: `/users/checkMembership/${normalizedEmail}`,
     method: "GET",
     authenticatedCall: false,
   });

--- a/src/pages/membership.tsx
+++ b/src/pages/membership.tsx
@@ -80,7 +80,7 @@ const Membership: React.FC = () => {
         const [hasMembership, userExists] = await Promise.all([
           checkMembership(userEmail),
           fetchBackend({
-            endpoint: `/users/check/${encodeURIComponent(userEmail)}`,
+            endpoint: `/users/check/${userEmail}`,
             method: "GET",
             authenticatedCall: false,
           }),


### PR DESCRIPTION
#### The bug
Was sending and using a encodeding function on email path params.

Backend commit added email validation without decoding the path parameter.

#### Fix
Removed encodeURIComponent() to email path params
Tested locally before merging