### PR TITLE
Membership Redirect to Home Page For Execs

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -46,7 +46,9 @@ export async function middleware(request: NextRequest) {
       nextServerContext: { request: request as any, response: response as any },
     });
 
-    const hasMembership = await checkMembership(userProfile.id);
+    const hasMembership = await checkMembership(
+      userProfile.email ?? userProfile.id,
+    );
 
     if (!hasMembership) {
       return NextResponse.redirect(new URL("/membership", request.url));

--- a/src/pages/admin/manage-members.tsx
+++ b/src/pages/admin/manage-members.tsx
@@ -93,7 +93,6 @@ type CreateMemberRequest = {
   dietaryRestrictions: string;
   referral: string;
   topics: string;
-  adminCreated: true;
 };
 
 const COLS_DEFAULT = {
@@ -168,7 +167,6 @@ export default function ManageMembers({ initialData }: Props) {
         dietaryRestrictions: values.dietaryRestrictions || "None",
         referral: values.referral,
         topics: values.topics.join(","),
-        adminCreated: true,
       };
 
       const response = await fetchBackend({

--- a/src/pages/membership.tsx
+++ b/src/pages/membership.tsx
@@ -12,6 +12,7 @@ import MembershipFormSection, {
   MembershipFormValues,
 } from "@/components/SignUpForm/MembershipFormSection";
 import { useToast } from "@/components/ui/use-toast";
+import { Toaster } from "@/components/ui/toaster";
 import {
   membershipValidationSchema,
   MEMBERSHIP_FORM_DEFAULTS,
@@ -167,8 +168,16 @@ const Membership: React.FC = () => {
           }),
         ]);
 
-        await fetchBackend({ endpoint: "/profiles", method: "POST" });
-        router.push(`/`);
+        // Profile creation can fail since we only update memberships each year
+        // Profiles may already exist since we don't update them each year, thus use a try catch block to prevent blocking the redirect
+        try {
+          await fetchBackend({ endpoint: "/profiles", method: "POST" });
+        } catch (profileError) {
+          console.error("Profile creation failed:", profileError);
+        }
+
+        window.location.assign("/");
+        return;
       } else {
         const paymentBody = {
           paymentName: "BizTech Membership",
@@ -231,6 +240,7 @@ const Membership: React.FC = () => {
 
   return (
     <FormProvider {...methods}>
+      <Toaster />
       <div className="flex min-h-screen flex-1 flex-col justify-center py-8 px-4 sm:px-6 lg:px-8 bg-bt-blue-600">
         <form
           className="max-w-xl mx-auto mt-12 px-4"

--- a/src/pages/membership.tsx
+++ b/src/pages/membership.tsx
@@ -139,44 +139,29 @@ const Membership: React.FC = () => {
 
     try {
       if (userBody.admin) {
-        await Promise.all([
-          fetchBackend({
-            endpoint: "/members",
-            method: "POST",
-            data: {
-              email: userBody.email,
-              education: userBody.education,
-              first_name: userBody.fname,
-              last_name: userBody.lname,
-              pronouns: userBody.gender,
-              student_number: userBody.studentId,
-              faculty: userBody.faculty,
-              year: userBody.year,
-              major: userBody.major,
-              prev_member: userBody.prev_member,
-              international: userBody.international,
-              topics: topicsString,
-              heard_from: values.referral,
-              diet: userBody.diet,
-              admin: userBody.admin,
-            },
-          }),
-          fetchBackend({
-            endpoint: isUser ? `/users/${userBody.email}` : "/users",
-            method: isUser ? "PATCH" : "POST",
-            data: { ...userBody, admin: undefined },
-          }),
-        ]);
+        await fetchBackend({
+          endpoint: "/members/grant",
+          method: "POST",
+          data: {
+            email: userBody.email,
+            firstName: userBody.fname,
+            lastName: userBody.lname,
+            studentNumber: userBody.studentId,
+            education: userBody.education,
+            pronouns: userBody.gender,
+            levelOfStudy: userBody.year,
+            faculty: userBody.faculty,
+            major: userBody.major,
+            internationalStudent: userBody.international,
+            previousMember: userBody.prev_member,
+            dietaryRestrictions: userBody.diet,
+            referral: values.referral,
+            topics: topicsString,
+          },
+        });
 
-        // Profile creation can fail since we only update memberships each year
-        // Profiles may already exist since we don't update them each year, thus use a try catch block to prevent blocking the redirect
-        try {
-          await fetchBackend({ endpoint: "/profiles", method: "POST" });
-        } catch (profileError) {
-          console.error("Profile creation failed:", profileError);
-        }
-
-        window.location.assign("/");
+        const redirectUrl = getQueryString(router.query.redirect) ?? "/";
+        window.location.assign(redirectUrl);
         return;
       } else {
         const paymentBody = {


### PR DESCRIPTION
## Describe your changes
When execs press create membership, the membership is created but the page is not redirected. It is because the promise all requires all three fetches (members, users, and profiles) to succeed. Since profiles are not replaced every year, the POST request fails, blocking the redirect. To fix this, I attached the profiles POST request to a try catch block, preventing the redirect request to be blocked if profile already exists. 

## Issue ticket number and link
UBC-45
https://linear.app/ubc-biztech/issue/UBC-45/no-membership-redirect-for-membership-page

## Checklist before requesting a review

- [x] I have performed a self-review of my code

## Images / Video of Feature