### PR TITLE
Added SSR prefetching on event homepage

### DIFF
--- a/src/features/events/home/EventHomePage.tsx
+++ b/src/features/events/home/EventHomePage.tsx
@@ -1,7 +1,6 @@
 import { useEvent, useEventCounts } from "@/queries/events";
 import { useUserRegistrations } from "@/queries/registrations";
 import { useUserAttributes } from "@/queries/user";
-import { useRouter } from "next/router";
 import { EventHeroHeader } from "./EventHeroHeader";
 import {
   defaultEventModules,
@@ -9,8 +8,10 @@ import {
 } from "./EventModuleRenderer";
 import type { EventHomeEvent, EventRegistrationRecord } from "./types";
 
-const getRouteParam = (value: string | string[] | undefined) =>
-  Array.isArray(value) ? value[0] : value;
+type EventHomePageProps = {
+  eventId: string;
+  year: string;
+};
 
 function EventHomeSkeleton() {
   return (
@@ -35,11 +36,7 @@ function EventHomeError() {
   );
 }
 
-export default function EventHomePage() {
-  const router = useRouter();
-  const eventId = getRouteParam(router.query.eventId);
-  const year = getRouteParam(router.query.year);
-
+export default function EventHomePage({ eventId, year }: EventHomePageProps) {
   const {
     data: event,
     isLoading: eventLoading,
@@ -58,18 +55,14 @@ export default function EventHomePage() {
 
   const signedIn = !!email;
   const registrationLoading =
-    userLoading || (signedIn ? registrationsLoading : false);
-  const registrationHref =
-    eventId && year
-      ? `/event/${eventId}/${year}/register`
-      : event
-        ? `/event/${event.id}/${event.year}/register`
-        : "/events";
+    (userLoading && email === undefined) ||
+    (signedIn && registrationsLoading && registration === undefined);
+  const registrationHref = `/event/${eventId}/${year}/register`;
 
   return (
     <main className="min-h-[calc(100vh-8rem)] bg-transparent text-white">
       <div className="mx-auto flex w-full max-w-[1260px] flex-col">
-        {!router.isReady || eventLoading ? (
+        {eventLoading && !event ? (
           <EventHomeSkeleton />
         ) : eventError || !event ? (
           <EventHomeError />

--- a/src/features/events/home/prefetchEventHome.ts
+++ b/src/features/events/home/prefetchEventHome.ts
@@ -1,0 +1,86 @@
+import { fetchBackendFromServer } from "@/lib/db";
+import type { Registration } from "@/queries/registrations";
+import type { UserAttributes } from "@/queries/user";
+import type { User } from "@/types";
+import { dehydrate, QueryClient } from "@tanstack/react-query";
+import type { GetServerSidePropsContext } from "next";
+
+type PrefetchResult =
+  | { notFound: true }
+  | {
+      dehydratedState: ReturnType<typeof dehydrate>;
+      eventId: string;
+      year: string;
+    };
+
+export async function prefetchEventHome(
+  context: GetServerSidePropsContext,
+): Promise<PrefetchResult> {
+  const eventId = context.params?.eventId;
+  const year = context.params?.year;
+
+  if (typeof eventId !== "string" || typeof year !== "string") {
+    return { notFound: true };
+  }
+
+  const nextServerContext = {
+    request: context.req,
+    response: context.res,
+  };
+  const queryClient = new QueryClient();
+
+  try {
+    const [event, counts] = await Promise.all([
+      fetchBackendFromServer({
+        endpoint: `/events/${eventId}/${year}`,
+        method: "GET",
+        authenticatedCall: false,
+        nextServerContext,
+      }),
+      fetchBackendFromServer({
+        endpoint: `/events/${eventId}/${year}?${new URLSearchParams({ count: String(true) })}`,
+        method: "GET",
+        authenticatedCall: false,
+        nextServerContext,
+      }),
+    ]);
+
+    queryClient.setQueryData(["events", eventId, year], event);
+    queryClient.setQueryData(["events", eventId, year, "counts"], counts);
+  } catch (error: any) {
+    if (error?.status === 404) {
+      return { notFound: true };
+    }
+  }
+
+  try {
+    const user: User = await fetchBackendFromServer({
+      endpoint: "/users/self",
+      method: "GET",
+      nextServerContext,
+    });
+    const email = user.email ?? user.id;
+    const userAttributes: UserAttributes = {
+      email,
+      isAdmin: Boolean(user.admin) || email.split("@")[1] === "ubcbiztech.com",
+    };
+
+    queryClient.setQueryData(["userAttributes"], userAttributes);
+
+    const registrationsResponse = await fetchBackendFromServer({
+      endpoint: `/registrations?email=${encodeURIComponent(email)}`,
+      method: "GET",
+      nextServerContext,
+    });
+    const registrations: Registration[] = registrationsResponse?.data || [];
+    queryClient.setQueryData(["registrations", email], registrations);
+  } catch {
+    queryClient.setQueryData(["userAttributes"], null);
+  }
+
+  return {
+    dehydratedState: dehydrate(queryClient),
+    eventId,
+    year,
+  };
+}

--- a/src/lib/queryProvider.tsx
+++ b/src/lib/queryProvider.tsx
@@ -1,9 +1,22 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
 import { useState, ReactNode } from "react";
 
-export function QueryProvider({ children }: { children: ReactNode }) {
+type QueryProviderProps = {
+  children: ReactNode;
+  dehydratedState?: ReturnType<typeof dehydrate>;
+};
+
+export function QueryProvider({
+  children,
+  dehydratedState,
+}: QueryProviderProps) {
   const [client] = useState(
     () =>
       new QueryClient({
@@ -16,5 +29,9 @@ export function QueryProvider({ children }: { children: ReactNode }) {
       }),
   );
 
-  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  return (
+    <QueryClientProvider client={client}>
+      <HydrationBoundary state={dehydratedState}>{children}</HydrationBoundary>
+    </QueryClientProvider>
+  );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -139,7 +139,7 @@ export default function App({ Component, pageProps }: AppProps) {
 
   // Otherwise, wrap it in the Layout
   return (
-    <QueryProvider>
+    <QueryProvider dehydratedState={pageProps.dehydratedState}>
       <Layout>{content}</Layout>
     </QueryProvider>
   );

--- a/src/pages/event/[eventId]/[year]/index.tsx
+++ b/src/pages/event/[eventId]/[year]/index.tsx
@@ -1,3 +1,21 @@
 import EventHomePage from "@/features/events/home/EventHomePage";
+import { prefetchEventHome } from "@/features/events/home/prefetchEventHome";
+import type { GetServerSideProps } from "next";
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const result = await prefetchEventHome(context);
+
+  if ("notFound" in result) {
+    return { notFound: true };
+  }
+
+  return {
+    props: {
+      eventId: result.eventId,
+      year: result.year,
+      dehydratedState: result.dehydratedState,
+    },
+  };
+};
 
 export default EventHomePage;


### PR DESCRIPTION
## Describe your changes
The homepage would show checking status for a few seconds whenever the page reloads/initial load. Thus, now the client side pre-fetches the data so on load, the actual status will show immediately. 

## Issue ticket number and link
UBC-46
https://linear.app/ubc-biztech/issue/UBC-46/add-ssr-for-event-homepage-specifically-event-registration-widget

## Checklist before requesting a review

- [x] I have performed a self-review of my code

## Images / Video of Feature
