### PR TITLE
Reroute path to work better with non members

### DIFF
--- a/src/pages/event/[eventId]/[year]/register/index.tsx
+++ b/src/pages/event/[eventId]/[year]/register/index.tsx
@@ -471,7 +471,7 @@ export default function AttendeeFormRegister() {
             </p>
             <button
               className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded shadow-md"
-              onClick={() => (window.location.href = "/")}
+              onClick={() => (window.location.href = "/events")}
             >
               Upcoming Events
             </button>
@@ -632,7 +632,7 @@ export default function AttendeeFormRegister() {
               </button>
               <button
                 className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded shadow-md"
-                onClick={() => (window.location.href = "/")}
+                onClick={() => (window.location.href = "/events")}
               >
                 Upcoming Events
               </button>
@@ -647,7 +647,7 @@ export default function AttendeeFormRegister() {
             </p>
             <button
               className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded shadow-md"
-              onClick={() => (window.location.href = "/")}
+              onClick={() => (window.location.href = "/events")}
             >
               Upcoming Events
             </button>
@@ -663,7 +663,7 @@ export default function AttendeeFormRegister() {
           </p>
           <button
             className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded shadow-md"
-            onClick={() => (window.location.href = "/")}
+            onClick={() => (window.location.href = "/events")}
           >
             Upcoming Events
           </button>
@@ -682,7 +682,7 @@ export default function AttendeeFormRegister() {
             </p>
             <button
               className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded shadow-md"
-              onClick={() => (window.location.href = "/")}
+              onClick={() => (window.location.href = "/events")}
             >
               Upcoming Events
             </button>

--- a/src/pages/event/[eventId]/[year]/register/partner/index.tsx
+++ b/src/pages/event/[eventId]/[year]/register/partner/index.tsx
@@ -123,7 +123,7 @@ export default function PartnerFormRegister() {
         <p className="text-l mb-4">You&apos;ve already registered!</p>
         <button
           className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded shadow-md"
-          onClick={() => (window.location.href = "/")}
+          onClick={() => (window.location.href = "/events")}
         >
           Upcoming Events
         </button>

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -6,6 +6,7 @@ import AttributesCard from "@/components/ProfilePage/AttributesCard";
 import SuggestedConnectionsCard from "@/components/ProfilePage/SuggestedConnectionsCard";
 import SuggestedConnectionsSection from "@/components/ProfilePage/SuggestedConnectionsSection";
 import { checkMembership } from "@/lib/membership";
+import { UnauthenticatedUserError } from "@/lib/dbUtils";
 
 interface ProfilePageProps {
   profileData: User;
@@ -66,9 +67,42 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
       profileData.email ?? profileData.id,
     );
 
+    if (!hasMembership) {
+      return {
+        redirect: {
+          destination: "/membership",
+          permanent: false,
+        },
+      };
+    }
+
     return { props: { profileData, hasMembership } };
-  } catch (error) {
+  } catch (error: any) {
     console.error("Error in getServerSideProps:", error);
+
+    if (
+      error?.name === UnauthenticatedUserError.name ||
+      error?.status === 401 ||
+      error?.status === 403 ||
+      error?.message === "Authentication required but no valid session found"
+    ) {
+      return {
+        redirect: {
+          destination: "/login?redirect=%2Fprofile",
+          permanent: false,
+        },
+      };
+    }
+
+    if (error?.status === 404) {
+      return {
+        redirect: {
+          destination: "/membership",
+          permanent: false,
+        },
+      };
+    }
+
     return {
       props: {
         profileData: null,


### PR DESCRIPTION
Make the "view events" buttons actually redirect to the /events path, instead of / (which causes the buy membership screen to show up)